### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/QACHECKOUT/f9f2f1ea-2009-41e5-891e-67c6edd18550/5381e7b6-17df-4a78-9c6c-c27dccbdf947/_apis/work/boardbadge/00e33d0c-e1b0-4997-976d-77648e9123c9)](https://dev.azure.com/QACHECKOUT/f9f2f1ea-2009-41e5-891e-67c6edd18550/_boards/board/t/5381e7b6-17df-4a78-9c6c-c27dccbdf947/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/QACHECKOUT/f9f2f1ea-2009-41e5-891e-67c6edd18550/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.